### PR TITLE
Fix handlers injection

### DIFF
--- a/src/QNF.Plataforma.API/Controllers/JogosController.cs
+++ b/src/QNF.Plataforma.API/Controllers/JogosController.cs
@@ -14,9 +14,10 @@ public class JogosController : ControllerBase
     private readonly RegistrarJogoHandler _handler;
     private readonly ValidarJogoHandler _validarHandler;
 
-    public JogosController(RegistrarJogoHandler handler)
+    public JogosController(RegistrarJogoHandler handler, ValidarJogoHandler validarHandler)
     {
         _handler = handler;
+        _validarHandler = validarHandler;
     }
 
     [HttpPost]

--- a/src/QNF.Plataforma.API/Program.cs
+++ b/src/QNF.Plataforma.API/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using QNF.Plataforma.Application.Jogos.Handlers;
+using QNF.Plataforma.Application.Grupos.Handlers;
+using QNF.Plataforma.Application.Duplas.Handlers;
 using QNF.Plataforma.Application.Rankings.Services;
 using QNF.Plataforma.Core.Interfaces;
 using QNF.Plataforma.Infrastructure.Data;
@@ -82,7 +84,6 @@ builder.Services.AddScoped<IValidacaoJogoRepository, ValidacaoJogoRepository>();
 builder.Services.AddScoped<IRankingRepository, RankingRepository>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 
-builder.Services.AddScoped<CriarJogadorHandler>();
 builder.Services.AddScoped<CriarGrupoHandler>();
 builder.Services.AddScoped<AdicionarJogadorAoGrupoHandler>();
 builder.Services.AddScoped<CriarDuplaHandler>();


### PR DESCRIPTION
## Summary
- wire up missing handler namespaces in Program.cs
- inject `ValidarJogoHandler` into `JogosController`
- remove unused reference to `CriarJogadorHandler`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628a24800c83298d57d733d08735a3