### PR TITLE
Fix missing repository registration

### DIFF
--- a/src/QNF.Plataforma.API/Program.cs
+++ b/src/QNF.Plataforma.API/Program.cs
@@ -78,6 +78,7 @@ builder.Services.AddScoped<IJogadorService, JogadorService>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<IJogadorRepository, JogadorRepository>();
 builder.Services.AddScoped<IGrupoRepository, GrupoRepository>();
+builder.Services.AddScoped<IJogadorGrupoRepository, JogadorGrupoRepository>();
 builder.Services.AddScoped<IDuplaRepository, DuplaRepository>();
 builder.Services.AddScoped<IJogoRepository, JogoRepository>();
 builder.Services.AddScoped<IValidacaoJogoRepository, ValidacaoJogoRepository>();


### PR DESCRIPTION
## Summary
- register `IJogadorGrupoRepository` in API DI container

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629e6ddd848329bc87cd03f7c45811